### PR TITLE
use strings.Fields() for whitespace separation

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -85,8 +85,7 @@ func (cpu *Cpu) Collect(c *MetricsCollection) (e error) {
 }
 
 func (cpu *Cpu) CollectCpu(c *MetricsCollection, line string) (metrics []*Metric) {
-	wsRe := regexp.MustCompile("[\\s]+")
-	chunks := wsRe.Split(line, -1)
+	chunks := strings.Fields(line)
 
 	re := regexp.MustCompile("^cpu(\\d+)")
 	mets := re.FindStringSubmatch(chunks[0])

--- a/df.go
+++ b/df.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 )
@@ -54,13 +53,12 @@ func CollectDf(t string, raw []byte, c *MetricsCollection) (e error) {
 		}
 	}
 	lines := strings.Split(strings.TrimSpace(string(raw)), "\n")
-	re := regexp.MustCompile("\\s+")
 	for _, line := range lines[1:] {
 		if !strings.HasPrefix(line, "/") {
 			continue
 		}
-		chunks := re.Split(line, 6)
-		if len(chunks) == 6 {
+		chunks := strings.Fields(line)
+		if len(chunks) >= 6 {
 			tags := map[string]string{
 				"file_system": chunks[0],
 				"mounted_on":  chunks[5],


### PR DESCRIPTION
strings.Fields is faster and simple to use for splitting by consecutive
ranges of various whitespace.

@tobstarr please take a look.
