### PR TITLE
Close http response body

### DIFF
--- a/util.go
+++ b/util.go
@@ -20,7 +20,7 @@ func FetchURL(url string) (b []byte, e error) {
 	if e != nil {
 		return
 	}
-
+	defer rsp.Body.Close()
 	b, e = ioutil.ReadAll(rsp.Body)
 	return
 }


### PR DESCRIPTION
Just something I noticed in the code while perusing it.  Per the docs:
http://golang.org/pkg/net/http/
"The client must close the response body when finished with it"
